### PR TITLE
Remove `.md` from whitelist

### DIFF
--- a/tools/build/change-version.js
+++ b/tools/build/change-version.js
@@ -103,7 +103,6 @@ function main(args) {
     '.js',
     '.es6',
     '.json',
-    '.md',
     '.scss',
     '.txt',
     '.yml',


### PR DESCRIPTION
When run command `yarn change-version vx.x.x vx.y.x` tag version from
CHANGELOG.md are accidentally replaced.